### PR TITLE
Remove Alias directive from systemd unit

### DIFF
--- a/deb/debian/homebridge.service
+++ b/deb/debian/homebridge.service
@@ -16,5 +16,4 @@ KillMode=process
 AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_RAW CAP_NET_ADMIN
 
 [Install]
-Alias=homebridge
 WantedBy=multi-user.target


### PR DESCRIPTION
## :recycle: Current situation

If a user runs `systemctl disable homebridge`, subsequent calls to `systemctl enable homebridge` may fail with the error "Invalid cross-device link".

## :bulb: Proposed solution

This removes the alias, which is unnecessary.