### PR TITLE
Add PolicyKit policy for resolved mDNS advertiser

### DIFF
--- a/deb/debian/homebridge.install
+++ b/deb/debian/homebridge.install
@@ -1,3 +1,4 @@
 var/lib/homebridge var/lib
+var/lib/polkit-1/localauthority/10-vendor.d/homebridge.pkla var/lib/polkit-1/localauthority/10-vendor.d
 opt/homebridge opt
 etc/hb-service etc

--- a/deb/debian/homebridge.service
+++ b/deb/debian/homebridge.service
@@ -6,6 +6,7 @@ After=syslog.target network-online.target
 [Service]
 Type=simple
 User=homebridge
+SupplementaryGroups=homebridge
 PermissionsStartOnly=true
 WorkingDirectory=/var/lib/homebridge
 ExecStartPre=-/bin/run-parts /etc/hb-service/homebridge/prestart.d

--- a/deb/var/lib/polkit-1/localauthority/10-vendor.d/homebridge.pkla
+++ b/deb/var/lib/polkit-1/localauthority/10-vendor.d/homebridge.pkla
@@ -1,0 +1,4 @@
+[Homebridge ManageService]
+Identity=unix-group:homebridge
+Action=org.freedesktop.resolve1.register-service;org.freedesktop.resolve1.unregister-service
+ResultAny=yes


### PR DESCRIPTION
## :recycle: Current situation

The `resolved` mDNS advertiser requires certain permissions in order to function properly. Currently, the user has to manually provide the appropriate PolicyKit policy.

## :bulb: Proposed solution

This deploys the policy as part of the package.

## :gear: Release Notes

- A PolicyKit policy has been added granting Homebridge the permissions necessary for the systemd-resolved mDNS advertiser to function properly.

## :heavy_plus_sign: Additional Information

See: homebridge/homebridge#3224, homebridge/HAP-NodeJS#965, homebridge/HAP-NodeJS#980, homebridge/HAP-NodeJS#982, oznu/homebridge-config-ui-x#1427

cc: @Supereg

### Testing

--

### Reviewer Nudging

--