### PR TITLE
Add PolicyKit policy for resolved mDNS advertiser

### DIFF
--- a/deb/debian/homebridge.install
+++ b/deb/debian/homebridge.install
@@ -1,4 +1,5 @@
 var/lib/homebridge var/lib
 var/lib/polkit-1/localauthority/10-vendor.d/homebridge.pkla var/lib/polkit-1/localauthority/10-vendor.d
+usr/share/polkit-1/rules.d/homebridge.rules usr/share/polkit-1/rules.d
 opt/homebridge opt
 etc/hb-service etc

--- a/deb/usr/share/polkit-1/rules.d/homebridge.rules
+++ b/deb/usr/share/polkit-1/rules.d/homebridge.rules
@@ -1,0 +1,7 @@
+polkit.addRule(function(action, subject) {
+    if ((action.id == "org.freedesktop.resolve1.register-service" ||
+         action.id == "org.freedesktop.resolve1.unregister-service") &&
+        subject.isInGroup("homebridge")) {
+        return polkit.Result.YES;
+    }
+});


### PR DESCRIPTION
## :recycle: Current situation

#2 added a PolicyKit policy in PolicyKit Local Authority format. `pklocalauthority` was deprecated and removed in polkit version 0.106. Systems running a more recent version won't have the policy applied to them.

## :bulb: Proposed solution

This adds an equivalent version of the policy in the current rule format. Since `pklocalauthority` is still used by several popular distributions (critically: Raspberry Pi OS), shipping both versions is prudent, and we retain that rule file.

## :gear: Release Notes

- The PolicyKit policy has been updated to use the current rule format.

## :heavy_plus_sign: Additional Information

https://github.com/homebridge/homebridge/issues/3224#issuecomment-1312064433

cc: @Supereg

### Testing

--

### Reviewer Nudging

--
