### PR TITLE
Create group if missing

### DIFF
--- a/deb/debian/postinst
+++ b/deb/debian/postinst
@@ -60,6 +60,12 @@ if [ "$1" = "configure" ]; then
   # create user
   adduser --system --group homebridge 2> /dev/null
 
+  # some old versions didn't create the homebridge group
+  if ! getent group homebridge > /dev/null; then
+    addgroup --system homebridge 2> /dev/null
+    usermod -g homebridge homebridge 2> /dev/null
+  fi
+
   # copy .bashrc to service user home
   cp /opt/homebridge/bashrc /home/homebridge/.bashrc
 


### PR DESCRIPTION
## :recycle: Current situation

Some old versions of the package didn't create a `homebridge` group. This causes problems now that the systemd service unit specifies that the service should be executed with `homebridge` as a supplementary group.

## :bulb: Proposed solution

This updates the `postinst` script to ensure that a `homebridge` group exists.

## :gear: Release Notes

- The package now ensures that a `homebridge` group exists.

## :heavy_plus_sign: Additional Information

Fixes: #3

### Testing

--

### Reviewer Nudging

--