### PR TITLE
add version and debug Flag

### DIFF
--- a/deb/opt/homebridge/hb-service-shim
+++ b/deb/opt/homebridge/hb-service-shim
@@ -178,6 +178,16 @@ case "$1" in
     exit 1
     ;;
 
+  "-V")
+    echo "Print Version Homebridge."
+    exec /var/lib/homebridge/node_modules/homebridge/bin/homebridge -V
+    ;;
+
+  "-D")
+    # Debug
+    exec /var/lib/homebridge/node_modules/homebridge/bin/homebridge -D
+    ;;
+
   *)
     printf '%s\n' \
       "Usage: hb-service [start|stop|restart|logs|status|update-node]"   \
@@ -196,6 +206,8 @@ case "$1" in
       "    logs                             tails the homebridge service logs" \
       "    status                           check if the Homebridge UI web server is running" \
       "    shell                            open the Homebridge Terminal" \
+      "    -V                               Print Homebridge Version" \
+      "    -D                               Debug Homebridge " \
       "" \
       "See the wiki for help with hb-service: https://homebridge.io/w/JTtHK"
     ;;


### PR DESCRIPTION
To have a uniform concept I think it is best to set the same Flags as the Homebridge-command.

: Current situation

The command "Homebridge" does not work as described in the Wiki.
It gives a error command not found after following the wiki with hb-service
So "Homebridge -D" and "Homebridge -V" does not work 

: Proposed solution

I think we can use the hb-service command with these flags so we have a uniform utilization 
sudo hb-service -V
sudo hb-service -D
