### PR TITLE
Uninstall homebridge and install version from package

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -64,12 +64,12 @@ npm install --location=global homebridge-config-ui-x
 HOMBRIDGE_CONFIG_VERSION="$(npm list -g --json=true | jq --raw-output '{version: .dependencies."homebridge-config-ui-x".version}.version')"
 echo "|Homebridge-Config-UI-X|" $HOMBRIDGE_CONFIG_VERSION "|" >> homebridge_apt_pkg_$NODE_ARCH.manifest
 
-npm install --location=global homebridge
-
-HOMBRIDGE_VERSION="$(npm list --json=true | jq --raw-output '{version: .dependencies."homebridge".version}.version')"
-echo "|Homebridge|" $HOMBRIDGE_VERSION "|" >> ${CWD}/homebridge_apt_pkg_$NODE_ARCH.manifest
+npm install --prefix $(pwd)/staging/var/lib/homebridge homebridge
 
 CWD=`pwd`
+cd staging/var/lib/homebridge
+HOMBRIDGE_VERSION="$(npm list --json=true | jq --raw-output '{version: .dependencies."homebridge".version}.version')"
+echo "|Homebridge|" $HOMBRIDGE_VERSION "|" >> ${CWD}/homebridge_apt_pkg_$NODE_ARCH.manifest
 
 cd ${CWD}/staging
 dpkg-buildpackage -us -uc

--- a/build.sh
+++ b/build.sh
@@ -64,12 +64,12 @@ npm install --location=global homebridge-config-ui-x
 HOMBRIDGE_CONFIG_VERSION="$(npm list -g --json=true | jq --raw-output '{version: .dependencies."homebridge-config-ui-x".version}.version')"
 echo "|Homebridge-Config-UI-X|" $HOMBRIDGE_CONFIG_VERSION "|" >> homebridge_apt_pkg_$NODE_ARCH.manifest
 
-npm install --prefix $(pwd)/staging/var/lib/homebridge homebridge
+npm install --location=global homebridge
 
-CWD=`pwd`
-cd staging/var/lib/homebridge
 HOMBRIDGE_VERSION="$(npm list --json=true | jq --raw-output '{version: .dependencies."homebridge".version}.version')"
 echo "|Homebridge|" $HOMBRIDGE_VERSION "|" >> ${CWD}/homebridge_apt_pkg_$NODE_ARCH.manifest
+
+CWD=`pwd`
 
 cd ${CWD}/staging
 dpkg-buildpackage -us -uc

--- a/deb/debian/postinst
+++ b/deb/debian/postinst
@@ -42,6 +42,17 @@ if [ "$1" = "configure" ] && [ -f /tmp/homebridge-tmp/package.json ] && [ -f /va
     fi
   fi
 
+  # remove homebridge from the package.json
+  if [ -e /var/lib/homebridge/package.json ]; then
+    if [ "$(cat /var/lib/homebridge/package.json | jq -r '.dependencies."homebridge"')" != "null" ]; then
+      packageJson="$(cat /var/lib/homebridge/package.json | jq -rM 'del(."dependencies"."homebridge")')"
+      if [ "$?" = "0" ]; then
+        printf "$packageJson" > /var/lib/homebridge/package.json
+        echo "Removed homebridge from package.json"
+      fi
+    fi
+  fi
+
   # Re-install user plugins
   echo "Refreshing user plugins, this may take a few minutes, please wait..."
   echo ""

--- a/deb/opt/homebridge/start.sh
+++ b/deb/opt/homebridge/start.sh
@@ -35,4 +35,18 @@ if [ -e "/var/lib/homebridge/node_modules/homebridge" ]; then
   rm -rf $HB_SERVICE_STORAGE_PATH/node_modules/homebridge
 fi
 
+# homebridge is removed from the package.json only in postinst
+# so this needs to be here on the first run to ensure the exidsting version is not reinstalled
+
+# remove homebridge from the package.json
+if [ -e /var/lib/homebridge/package.json ]; then
+  if [ "$(cat /var/lib/homebridge/package.json | jq -r '.dependencies."homebridge"')" != "null" ]; then
+    packageJson="$(cat /var/lib/homebridge/package.json | jq -rM 'del(."dependencies"."homebridge")')"
+    if [ "$?" = "0" ]; then
+      printf "$packageJson" > /var/lib/homebridge/package.json
+      echo "Removed homebridge from package.json"
+    fi
+  fi
+fi
+
 exec $HB_SERVICE_NODE_EXEC_PATH $HB_SERVICE_EXEC_PATH run -I -U $HB_SERVICE_STORAGE_PATH -P $HB_SERVICE_STORAGE_PATH/node_modules --strict-plugin-resolution "$@"

--- a/deb/opt/homebridge/start.sh
+++ b/deb/opt/homebridge/start.sh
@@ -25,16 +25,14 @@ if [ -e /var/lib/homebridge/package-lock.json ]; then
   rm -rf /var/lib/homebridge/package-lock.json
 fi
 
-# check for missing homebridge
-if [ ! -f "$HB_SERVICE_STORAGE_PATH/node_modules/homebridge/package.json" ]; then
-  cd $HB_SERVICE_STORAGE_PATH
-  echo "Re-installing homebridge..."
-  npm --prefix $HB_SERVICE_STORAGE_PATH install --save homebridge@latest
-fi
-
 # remove homebridge-config-ui-x package from the plugins store
 if [ -e "/var/lib/homebridge/node_modules/homebridge-config-ui-x" ]; then
   rm -rf $HB_SERVICE_STORAGE_PATH/node_modules/homebridge-config-ui-x
+fi
+
+# remove homebridge package from the plugins store
+if [ -e "/var/lib/homebridge/node_modules/homebridge" ]; then
+  rm -rf $HB_SERVICE_STORAGE_PATH/node_modules/homebridge
 fi
 
 exec $HB_SERVICE_NODE_EXEC_PATH $HB_SERVICE_EXEC_PATH run -I -U $HB_SERVICE_STORAGE_PATH -P $HB_SERVICE_STORAGE_PATH/node_modules --strict-plugin-resolution "$@"


### PR DESCRIPTION
## :recycle: Current situation

Currently, if a version of Homebridge is installed, it is not updated

## :bulb: Proposed solution

Delete existing version of Homebridge from `node_modules`, delete version from local `package.json` and install version from apt `package.json`

## :gear: Release Notes

Updates Homebridge version to version in `package.json`

## :heavy_plus_sign: Additional Information

As the homebridge version is removed from the local package.json only in postinst, we need an initial delete of the existing version of Homebridge from the local package.json on the first run to prevent reinstalling the same package. Future runs will be fine.

### Testing


### Reviewer Nudging

